### PR TITLE
Add songs from liked albums to playlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Later I will add an optional flag to disable this behaviour (and let the user ma
 
 ## Features
 - [x] Authorization Code flow with state and refresh tokens
-- [ ] Export library to CSV
 - [x] Export a playlist to CSV by name
+- [x] Add all songs from liked albums to delegate playlist
+- [ ] Export library to CSV
 - [ ] Export a list of playlists by comma-separated names
 - [ ] View list of most recent _n_ playlists

--- a/src/Application/Commands/AddCommand.cs
+++ b/src/Application/Commands/AddCommand.cs
@@ -1,0 +1,29 @@
+using Application.Handlers;
+using Application.Spotify;
+using Application.CLI.Arguments;
+
+namespace Application.Commands;
+
+public class AddCommand : Command
+{
+  public override string Alias
+  {
+    get
+    {
+      return "add";
+    }
+  }
+
+  public override string Description
+  {
+    get
+    {
+      return "Add the specified items to a delegate resource.";
+    }
+  }
+
+  public override Func<Client, ArgumentParser, Task<int>> GetDispatcher()
+  {
+    return (Client client, ArgumentParser argParser) => AddHandler.Dispatch(client, argParser);
+  }
+}

--- a/src/Application/Commands/Commands.cs
+++ b/src/Application/Commands/Commands.cs
@@ -7,6 +7,7 @@ public class Commands
     new LoginCommand(),
     new HelpCommand(),
     new LogoutCommand(),
-    new ExportCommand()
+    new ExportCommand(),
+    new AddCommand(),
   };
 }

--- a/src/Application/Handlers/AddHandler.cs
+++ b/src/Application/Handlers/AddHandler.cs
@@ -23,7 +23,7 @@ public class AddHandler
       return 1;
     }
 
-    // Call client here
+    await client.AddAlbumsToPlaylist(destination);
 
     return 0;
   }

--- a/src/Application/Handlers/AddHandler.cs
+++ b/src/Application/Handlers/AddHandler.cs
@@ -1,0 +1,30 @@
+namespace Application.Handlers;
+
+public class AddHandler
+{
+  private static class AllowedResources
+  {
+    public static readonly string[] RESOURCES = { "albums" };
+  }
+
+  public static async Task<int> Dispatch(Application.Spotify.Client client, Application.CLI.Arguments.ArgumentParser argParser)
+  {
+    var resource = argParser.NextArg();
+    if (String.IsNullOrWhiteSpace(resource) || !AllowedResources.RESOURCES.Contains(resource))
+    {
+      // Show some message about allowed resources
+      return 1;
+    }
+
+    var destination = argParser.NextArg();
+    if (String.IsNullOrWhiteSpace(destination))
+    {
+      // Show some message about being a required argument
+      return 1;
+    }
+
+    // Call client here
+
+    return 0;
+  }
+}

--- a/src/Application/Spotify/Bases/ClientAuth.cs
+++ b/src/Application/Spotify/Bases/ClientAuth.cs
@@ -18,7 +18,7 @@ public abstract class ClientAuth
   private readonly string _clientSecret = Variables.RequireEnvVar("SPOTIFY_CLIENT_SECRET");
   private readonly string _redirectUri = Variables.RequireEnvVar("SPOTIFY_REDIRECT_URI");
   private readonly string _responseType = "code";
-  private readonly string _scopes = "user-library-read+playlist-read-private";
+  private readonly string _scopes = "user-library-read+playlist-read-private+playlist-modify-public";
   private string _state;
   private string _authToken = String.Empty;
   private AccessToken? _accessTokenResponse;

--- a/src/Application/Spotify/Constants.cs
+++ b/src/Application/Spotify/Constants.cs
@@ -4,4 +4,10 @@ public class Constants
 {
   public static readonly string API_BASE_URL = "https://api.spotify.com/v1";
   public static readonly string ACCOUNTS_BASE_URL = "https://accounts.spotify.com";
+
+  public static class Playlist
+  {
+    public static readonly int MAX_LENGTH = 11_000;
+    public static readonly int MAX_SONGS_TO_ADD = 100;
+  }
 }

--- a/src/Application/Spotify/Responses/Album.cs
+++ b/src/Application/Spotify/Responses/Album.cs
@@ -2,7 +2,7 @@ using System.Text.Json.Serialization;
 
 namespace Application.Spotify.Responses;
 
-public record class Album(
+public record class AlbumLite(
   [property: JsonPropertyName("href")] string Href,
   [property: JsonPropertyName("id")] string Id,
   [property: JsonPropertyName("name")] string Name,

--- a/src/Application/Spotify/Responses/Album.cs
+++ b/src/Application/Spotify/Responses/Album.cs
@@ -9,3 +9,25 @@ public record class AlbumLite(
   [property: JsonPropertyName("artists")] Artist[] Artists,
   [property: JsonPropertyName("uri")] string URI
 );
+
+public record class AlbumTrack(
+  [property: JsonPropertyName("artists")] Artist[] Artists,
+  [property: JsonPropertyName("href")] string Href,
+  [property: JsonPropertyName("id")] string Id,
+  [property: JsonPropertyName("name")] string Name,
+  [property: JsonPropertyName("uri")] string URI
+);
+
+public record class Album(
+  [property: JsonPropertyName("href")] string Href,
+  [property: JsonPropertyName("id")] string Id,
+  [property: JsonPropertyName("name")] string Name,
+  [property: JsonPropertyName("artists")] Artist[] Artists,
+  [property: JsonPropertyName("uri")] string URI,
+  [property: JsonPropertyName("tracks")] Pagination<AlbumTrack> TracksPage
+);
+
+public record class AlbumWithAddedAt(
+  [property: JsonPropertyName("added_at")] DateTime AddedAt,
+  [property: JsonPropertyName("album")] Album Album
+);

--- a/src/Application/Spotify/Responses/Playlist.cs
+++ b/src/Application/Spotify/Responses/Playlist.cs
@@ -23,3 +23,7 @@ public record class Playlist(
   [property: JsonPropertyName("tracks")] Pagination<TrackWithAddedAt> Tracks,
   [property: JsonPropertyName("uri")] string Uri
 );
+
+public record class PlaylistSnapshot(
+  [property: JsonPropertyName("snapshot_id")] string SnapshotId
+);

--- a/src/Application/Spotify/Responses/Track.cs
+++ b/src/Application/Spotify/Responses/Track.cs
@@ -8,7 +8,7 @@ public record class TracksLite(
 );
 
 public record class Track(
-  [property: JsonPropertyName("album")] Album Album,
+  [property: JsonPropertyName("album")] AlbumLite Album,
   [property: JsonPropertyName("artists")] Artist[] Artists,
   [property: JsonPropertyName("href")] string Href,
   [property: JsonPropertyName("id")] string Id,

--- a/src/Application/Spotify/Responses/User.cs
+++ b/src/Application/Spotify/Responses/User.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace Application.Spotify.Responses;
+
+public record class User(
+  [property: JsonPropertyName("country")] string Country,
+  [property: JsonPropertyName("display_name")] string DisplayName,
+  [property: JsonPropertyName("id")] string Id
+);

--- a/src/Application/Spotify/Spotify.cs
+++ b/src/Application/Spotify/Spotify.cs
@@ -183,7 +183,17 @@ public class Client : ClientAuth, ISpotifyClient
 
   private async Task<T> AuthedRequest<T>(HttpMethod method, string link)
   {
+    return await AuthedRequest<T>(method, link, null);
+  }
+
+  private async Task<T> AuthedRequest<T>(HttpMethod method, string link, string? body)
+  {
     var request = new HttpRequestMessage(method, link);
+    if (body != null)
+    {
+      request.Content = new StringContent(body);
+    }
+
     request.Headers.Add("Authorization", $"Bearer {this.AccessToken}");
     var response = await Http.SendRequestAndParseAs<T>(request, this.httpClient);
     if (response == null)

--- a/src/Application/Spotify/Spotify.cs
+++ b/src/Application/Spotify/Spotify.cs
@@ -165,6 +165,15 @@ public class Client : ClientAuth, ISpotifyClient
     return await AuthedRequest<User>(HttpMethod.Get, url);
   }
 
+  public async Task<string> CreatePlaylist(string playlistName)
+  {
+    var currentUserId = (await GetCurrentUser()).Id;
+    string url = $"{Constants.API_BASE_URL}/users/{currentUserId}/playlists";
+    string body = $"{{\"name\":\"{playlistName}\"}}";
+
+    return (await AuthedRequest<PlaylistLite>(HttpMethod.Post, url, body)).Id;
+  }
+
   private async Task<List<T>> HandlePagination<T>(string firstPageLink)
   {
     var results = new List<T>();

--- a/src/Application/Spotify/Spotify.cs
+++ b/src/Application/Spotify/Spotify.cs
@@ -159,6 +159,12 @@ public class Client : ClientAuth, ISpotifyClient
     return await HandlePagination<TrackWithAddedAt>(firstPage);
   }
 
+  public async Task<User> GetCurrentUser()
+  {
+    string url = $"{Constants.API_BASE_URL}/me";
+    return await AuthedRequest<User>(HttpMethod.Get, url);
+  }
+
   private async Task<List<T>> HandlePagination<T>(string firstPageLink)
   {
     var results = new List<T>();


### PR DESCRIPTION
When you "like" an album, it doesn't like the individual tracks (hasn't done for some time, actually). This feature will let you add all the songs from albums you like to a playlist of your choosing. It goes into a playlist for now since then I don't need to figure out what songs have already been liked 😅 I might do that later.

## Usage
```bash
dotnet run add albums <playlist-name>
```

`<playlist-name>` will be created for you, regardless of whether it already exists or not.

### Bonus!
I learned while writing this that the maximum number of songs Spotify allows in a playlist is 11000 (as of Feb 2023). Who knew? If this process results in more songs than that for you (it did for me!), multiple playlists will be made, following the scheme `$"{playlistName} {counter}"`. In this case, you can then add the resulting playlists to a folder in Spotify, and play the whole folder to simulate a single playlist. 🤷